### PR TITLE
[BREAKING-CHANGES] security updates needs at least go version >=1.17 with security updates

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        redis-version: [4, 5, 6]
+        redis-version: [6]
         go: ["1.17", "1.18"]
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   allow_failures:
     - go: tip
 
-go_import_path: github.com/gritzkoo/golang-health-checker
+go_import_path: github.com/gritzkoo/golang-health-checker/v2
 
 before_install:
   - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s --

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gritzkoo/golang-health-checker
+module github.com/gritzkoo/golang-health-checker/v2
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gritzkoo/golang-health-checker/pkg/healthcheck"
+	"github.com/gritzkoo/golang-health-checker/v2/pkg/healthcheck"
 )
 
 func main() {


### PR DESCRIPTION
[Dependabot alert fix] - Unhandled exception in gopkg.in/yaml.v3 #1
- update `go.mod` go version up to `1.18`
- update direct and indirect dependencies
PS: during the first steps of this update, tests using go version <1.17 fails because of their dependencies requirements.